### PR TITLE
Fix MSan warning in get_fqhostname()

### DIFF
--- a/lib/saslutil.c
+++ b/lib/saslutil.c
@@ -522,7 +522,7 @@ int get_fqhostname(
 )
 {
     int return_value;
-    struct addrinfo hints;
+    struct addrinfo hints = {};
     struct addrinfo *result;
 
     return_value = gethostname (name, namelen);


### PR DESCRIPTION
MSan reports [1]:

    Uninitialized bytes in __interceptor_getaddrinfo at offset 20 inside [0x7febe03d1ec0, 48)
    ==7==WARNING: MemorySanitizer: use-of-uninitialized-value
        #0 0x3bcc351d in get_fqhostname obj-x86_64-linux-gnu/../contrib/cyrus-sasl/lib/saslutil.c:548:9
        #1 0x3bcf6e7f in sasl_client_new obj-x86_64-linux-gnu/../contrib/cyrus-sasl/lib/client.c:515:7
        #2 0x3bb91c19 in rd_kafka_sasl_cyrus_client_new obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_sasl_cyrus.c:500:13
        #3 0x3bacfd9d in rd_kafka_sasl_client_new obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_sasl.c:265:13
        #4 0x3b689f83 in rd_kafka_broker_connect_auth obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:2263:8
        #5 0x3b6a4075 in rd_kafka_broker_handle_SaslHandshake obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:2199:2
        #6 0x3b70c8e3 in rd_kafka_buf_callback obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_buf.c:480:17
        #7 0x3b681189 in rd_kafka_req_response obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:1775:9
        #8 0x3b681189 in rd_kafka_recv obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:1893:3
        #9 0x3bb18ff2 in rd_kafka_transport_io_event obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_transport.c:742:11
        #10 0x3bb18ff2 in rd_kafka_transport_io_serve obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_transport.c:801:17
        #11 0x3b6bd7b3 in rd_kafka_broker_ops_io_serve obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:3380:21
        #12 0x3b6adb2d in rd_kafka_broker_consumer_serve obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:4961:17
        #13 0x3b6adb2d in rd_kafka_broker_serve obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:5066:17
        #14 0x3b694799 in rd_kafka_broker_thread_main obj-x86_64-linux-gnu/../contrib/librdkafka/src/rdkafka_broker.c:5208:25
        #15 0x3bb86676 in _thrd_wrapper_function obj-x86_64-linux-gnu/../contrib/librdkafka/src/tinycthread.c:576:9
        #16 0x7fecf4eaf608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9608)
        #17 0x7fecf4dd6292 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x122292)

      Uninitialized value was created by an allocation of 'hints' in the stack frame of function 'get_fqhostname'
        #0 0x3bcc31b0 in get_fqhostname obj-x86_64-linux-gnu/../contrib/cyrus-sasl/lib/saslutil.c:523

    SUMMARY: MemorySanitizer: use-of-uninitialized-value obj-x86_64-linux-gnu/../contrib/cyrus-sasl/lib/saslutil.c:548:9 in get_fqhostname

  [1]: https://clickhouse-test-reports.s3.yandex.net/0/f7edcdf7c847f7d45ceede4a6073400ec2c985b7/integration_tests_(memory).html

Note that we can use __msan_unpoison() instead, but this function does
not looks hot, so it does not worth the complexity.